### PR TITLE
[BUGFIX] removing depreciated nodeModulesPath.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 /* jshint node: true */
 'use strict';
 
-var path = require('path');
 var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-normalize',
 
   treeForStyles: function() {
-    var normalizePath = path.join(this.project.nodeModulesPath, 'normalize.css');
+    var normalizePath = this.project.resolveSync('normalize.css');
     var normalizeTree = new Funnel(this.treeGenerator(normalizePath), {
       srcDir: '/',
       destDir: '/app/styles'

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
 var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-normalize',
 
   treeForStyles: function() {
-    var normalizePath = this.project.resolveSync('normalize.css');
-    var normalizeTree = new Funnel(this.treeGenerator(normalizePath), {
-      srcDir: '/',
-      destDir: '/app/styles'
+    var normalizeModulePath = path.dirname(this.project.resolveSync('normalize.css'));
+    var normalizeTree = new Funnel(this.treeGenerator(normalizeModulePath), {
+      destDir: 'app/styles',
+      include: ['normalize.css']
     });
 
     return normalizeTree;


### PR DESCRIPTION
based off of https://github.com/ember-cli/ember-cli/pull/7401 `nodeModulesPath` has been depreciated, and `resolveSync` is a preferred alternative. `nodeModulesPath` has been removed in Ember Cli 3.x and it's use here breaks 3.x builds.