### PR TITLE
Update normalize.css import method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,12 @@
 /* jshint node: true */
 'use strict';
 
-var path = require('path');
-var Funnel = require('broccoli-funnel');
-
 module.exports = {
   name: 'ember-normalize',
 
-  treeForStyles: function() {
-    var normalizePath = path.join(this.project.nodeModulesPath, 'normalize.css');
-    var normalizeTree = new Funnel(this.treeGenerator(normalizePath), {
-      srcDir: '/',
-      destDir: '/app/styles'
-    });
+  included: function(app) {
+    this._super.included(app);
 
-    return normalizeTree;
+    app.import('node_modules/normalize.css/normalize.css');
   }
 };

--- a/tests/acceptance/sanity-test.js
+++ b/tests/acceptance/sanity-test.js
@@ -9,6 +9,6 @@ test('normalize styles are being applied', function(assert) {
 
   andThen(() => {
     let fontFamily = jQuery('pre').css('font-family');
-    assert.equal(fontFamily, 'monospace, monospace', 'PRE has expected font-family');
+    assert.equal(fontFamily, 'monospace', 'PRE has expected font-family');
   });
 });


### PR DESCRIPTION
Resolves #16 by using the current ember-cli `app.import` syntax that now works from `node_modules`. Tested and verified with my ember-cli@3.0.0 projects.